### PR TITLE
Remove the BEGIN/END messages

### DIFF
--- a/src/main/java/fr/pilato/elasticsearch/injector/injector/ConsoleInjector.java
+++ b/src/main/java/fr/pilato/elasticsearch/injector/injector/ConsoleInjector.java
@@ -48,7 +48,6 @@ public class ConsoleInjector extends Injector {
 
     @Override
     public void internalStart() {
-        System.out.println("******** STARTING GENERATING PERSONS ********");
     }
 
     @Override
@@ -67,6 +66,5 @@ public class ConsoleInjector extends Injector {
 
     @Override
     public void close() {
-        System.out.println("******** END OF PERSONS GENERATION ********");
     }
 }


### PR DESCRIPTION
When using the CONSOLE output, it's not useful to see the BEGIN/END messages as it does not allow to use directly the dataset then.